### PR TITLE
Change process names to use ImageFilePointer->FileName on Win10

### DIFF
--- a/hlapi/winprocesslist.cpp
+++ b/hlapi/winprocesslist.cpp
@@ -63,6 +63,15 @@ WinProcessList::~WinProcessList()
 void WinProcessList::FreeProcessList()
 {
 	if (plist.list)
+	{
+		if (ctx->ntVersion == 1000)
+		{
+			for (size_t i = 0; i < plist.size; i++)
+				free(plist.list[i].name);
+		}
+
 		free(plist.list);
+	}
+
 	plist.list = nullptr;
 }

--- a/wintools.h
+++ b/wintools.h
@@ -31,7 +31,7 @@ typedef struct WinProc
 	uint64_t physProcess;
 	uint64_t dirBase;
 	uint64_t pid;
-	char name[16];
+	char* name;
 } WinProc;
 
 typedef struct WinProcList


### PR DESCRIPTION
Currently process names are retrieved from ImageFileName inside the EPROCESS structure which is a fixed size array. This causes long process names to be truncated.

A better way is to use ImageFilePointer->FileName to get the full path of the image then get the base name of that path. Using this method the name is not truncated.

This struct member only exists on Windows 10 as far as I can tell.