### PR TITLE
Specify project version and fix unknown option warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('vmread', 'cpp', 'c', default_options : ['c_std=c99', 'c++_std=c++11'])
+project('vmread', 'cpp', 'c', version : '1.3', default_options : ['c_std=c99', 'cpp_std=c++11'])
 
 compile_args = ['-D_POSIX_C_SOURCE=200809L', '-D_DEFAULT_SOURCE', '-pedantic', '-DMVERBOSE=4', '-DMTR_ENABLED', '-DREAD_CHECK']
 compile_args_external = ['-DLMODE=MODE_EXTERNAL', '-fsanitize=address']


### PR DESCRIPTION
Meson gives the warning `WARNING: Unknown options: "c++_std"`. This is fixed by instead defining cpp_std=c++11 in default options. Meson also reports `Project version: undefined` which is easily fixed by specifying the current project version.